### PR TITLE
Update Exceptions.ts

### DIFF
--- a/src/Exceptions.ts
+++ b/src/Exceptions.ts
@@ -1,4 +1,4 @@
-export class BaseException{constructor(){Error.apply(this, arguments)}}
+export class BaseException{constructor(){Error.apply(this, arguments[1])}}
 export class Exc extends BaseException{constructor(public code: number, public message: string){super()}}
 export class IntExc extends BaseException{constructor(public code: number, public message: string){super()}}
 


### PR DESCRIPTION
Fixes
```typescript
node_modules/hypixel-api-typescript/src/Exceptions.ts:1:60 - error TS2345: Argument of type 'IArguments' is not assignable to parameter of type '[(string | undefined)?]'.

1 export class BaseException{constructor(){Error.apply(this, arguments)}}
```
Arguments needs to be a String for some reason. This may be a dirty fix I don't know.